### PR TITLE
Update ProdutoContext.cs

### DIFF
--- a/LysiSolutionNumber01/Models/Context/ProdutoContext.cs
+++ b/LysiSolutionNumber01/Models/Context/ProdutoContext.cs
@@ -10,7 +10,8 @@ namespace TodoApi.Models
         {
         }
 
-        public DbSet<Produto> Registros { get; set; }
+        public DbSet<Produto> Produtos { get; set; }
+        public DbSet<Grupos> Grupos { get; set; }
 
     }
 }


### PR DESCRIPTION
Adicionado a propriedade grupo.

Talvez o mais indicado é que você altere o nome do "ProdutoContext" pois a ideia é que este DbContext seja para todos do sistema e não um para cada um, ou seja, se entrar uma nova tabela, ao invés de você criar outro context, você adiciona uma nova propriedade neste arquivo.